### PR TITLE
v2.0.1

### DIFF
--- a/src/APIv2/APIv2.js
+++ b/src/APIv2/APIv2.js
@@ -44,8 +44,10 @@ const getRemainingClasses = async () => {
     const allRemainingClasses = []
 
     //For each ClassEvent in Classes, format the ClassEvent into a Period, and add that Period into the allRemainingClasses array
-    for await (const ClassEvent of Classes) {
-        const Class = new Period(ClassEvent.summary, ClassEvent.start.toLocaleString(), ClassEvent.end.toLocaleString, ClassEvent.location)
+    for await (let ClassEvent of Classes) {
+        ClassEvent.start = await iCalFunctions.UTCtoLocalTime(ClassEvent.start);
+        ClassEvent.end = await iCalFunctions.UTCtoLocalTime(ClassEvent.end);
+        const Class = new Period(ClassEvent.summary, ClassEvent.start, ClassEvent.end, ClassEvent.location)
         allRemainingClasses.push(Class)
     }
     //Once finished, return allRemainingClasses

--- a/src/APIv2/iCal-Functions.js
+++ b/src/APIv2/iCal-Functions.js
@@ -10,8 +10,7 @@ getCurrentCycleEvent = async () => {
   for await (const CycleDayEvent of Object.values(Calendar)) {
 
     //If statement to find the one CycleDayEvent that corresponds to Today's Date. Ignores time
-    if (CycleDayEvent.start.toISOString().split("T").slice(0, -1)[0] === Today.toISOString().split("T").slice(0, -1)[0]) {
-
+    if (CycleDayEvent.start.toString().slice(0, 15) === Today.toString().slice(0, 15)) {
       //Once found a match, return CycleDayEvent back to the APIv2.js file
       return CycleDayEvent
     }

--- a/src/APIv2/iCal-Functions.js
+++ b/src/APIv2/iCal-Functions.js
@@ -2,7 +2,7 @@
 const ical = require("node-ical");
 const config = require("../util/config.js")
 
-getCurrentCycleEvent = async () => {
+const getCurrentCycleEvent = async () => {
   const Calendar = await ical.async.fromURL("https://calendar.google.com/calendar/ical/hollandhall.org_rqggarpb66eqmgm80dg7n8atqg%40group.calendar.google.com/public/basic.ics");
   const Today = await new Date()
 
@@ -17,9 +17,9 @@ getCurrentCycleEvent = async () => {
   }
 }
 
-getRemainingClasses = async () => {
+const getRemainingClasses = async () => {
   const Calendar = await ical.async.fromURL(config.personalCalendar)
-  const CurrentDateTime = await new Date()
+  const CurrentDateTime = await new Date();
 
   //Create an array to store all Classes
   const ClassArray = []
@@ -45,9 +45,19 @@ getRemainingClasses = async () => {
 }
 
 
+//Extra function to convert UTC time to local time
+const UTCtoLocalTime = (datetime) => {
+  const formattedDate = new Date(datetime.getTime() + datetime.getTimezoneOffset() *60 * 1000);
+        const offset = datetime.getTimezoneOffset() / 60;
+        const hours = datetime.getHours();
+        formattedDate.setHours(hours - offset);
+        return formattedDate
+}
+
 
 //Exports all functions
 module.exports = {
   getCurrentCycleEvent,
-  getRemainingClasses
+  getRemainingClasses,
+  UTCtoLocalTime
 }


### PR DESCRIPTION
Fixed UTC standard time issue [#1](https://github.com/Cordial21/HH-Calendar-API/issues/1

Now displays local Central time, and uses Central time for all time-related activities in function CycleDay